### PR TITLE
Add new grid manager node aipanda156

### DIFF
--- a/GRID/common_grid_queueconfig_template.json
+++ b/GRID/common_grid_queueconfig_template.json
@@ -24,12 +24,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -92,12 +94,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -162,12 +166,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -232,12 +238,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -300,12 +308,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -370,12 +380,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -440,12 +452,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -511,12 +525,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -579,12 +595,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -649,12 +667,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],
@@ -720,12 +740,14 @@
           "condorSchedd":[
               "aipanda023.cern.ch",
               "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
               "aipanda183.cern.ch",
               "aipanda184.cern.ch"
           ],
           "condorPool":[
               "aipanda023.cern.ch:19618",
               "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
               "aipanda183.cern.ch:19618",
               "aipanda184.cern.ch:19618"
           ],


### PR DESCRIPTION
The HTCondor grid manager node `aipanda183` had issues because of CPU
steal induced byt a build node on the same hypervisor. While the build
node has been removed we add this condor node to balance the work of the
grid managers.