### PR TITLE
Add non-ups intel template; rename intel ups template

### DIFF
--- a/GRID/common_grid_queueconfig_template.json
+++ b/GRID/common_grid_queueconfig_template.json
@@ -714,8 +714,78 @@
           "module":"pandaharvester.harvestersweeper.htcondor_sweeper"
       }
   },
-
   "US_analysis_pull_intel":{
+      "isTemplateQueue": true,
+      "prodSourceLabel":"user",
+      "prodSourceLabelRandomWeightsPermille": {"ptest":10, "rc_test":10, "rc_test2":10, "rc_alrb":10},
+      "nQueueLimitWorkerRatio":60,
+      "nQueueLimitWorkerMax":500,
+      "nQueueLimitWorkerMin":100,
+      "maxWorkers":999999,
+      "maxNewWorkersPerCycle":100,
+      "mapType":"NoJob",
+      "truePilot":true,
+      "maxSubmissionAttempts":3,
+      "walltimeLimit":1209600,
+      "prefetchEvents":false,
+      "preparator":{
+          "name":"DummyPreparator",
+          "module":"pandaharvester.harvesterpreparator.dummy_preparator"
+      },
+      "submitter":{
+          "name":"HTCondorSubmitter",
+          "module":"pandaharvester.harvestersubmitter.htcondor_submitter",
+          "condorSchedd":[
+              "aipanda023.cern.ch",
+              "aipanda024.cern.ch",
+              "aipanda156.cern.ch",
+              "aipanda183.cern.ch",
+              "aipanda184.cern.ch"
+          ],
+          "condorPool":[
+              "aipanda023.cern.ch:19618",
+              "aipanda024.cern.ch:19618",
+              "aipanda156.cern.ch:19618",
+              "aipanda183.cern.ch:19618",
+              "aipanda184.cern.ch:19618"
+          ],
+          "useSpool":false,
+          "useAtlasGridCE":true,
+          "templateFile":"/cephfs/atlpan/harvester/harvester_common/htcondor_atlas-grid-ce_pull.sdf.d/htcondor-ce-intel_pilot2.sdf",
+          "x509UserProxy":"/cephfs/atlpan/harvester/proxy/x509up_u25606_prod",
+          "logDir":"/data2/atlpan/condor_logs",
+          "logBaseURL":"https://[ScheddHostname]/condor_logs_2",
+          "nProcesses":8
+      },
+      "workerMaker":{
+          "name":"SimpleWorkerMaker",
+          "module":"pandaharvester.harvesterworkermaker.simple_worker_maker",
+          "jobAttributesToUse":[
+              "nCore"
+          ],
+          "pilotTypeRandomWeightsPermille": {"RC": 10, "ALRB": 10, "PT": 10}
+      },
+      "messenger":{
+          "name":"SharedFileMessenger",
+          "module":"pandaharvester.harvestermessenger.shared_file_messenger",
+          "jobSpecFileFormat":"cgi",
+          "accessPoint":"/cephfs/atlpan/harvester/harvester_wdirs/${harvesterID}/${_workerID_3.2}/${_workerID_1.0}/${workerID}"
+      },
+      "stager":{
+          "name":"DummyStager",
+          "module":"pandaharvester.harvesterstager.dummy_stager"
+      },
+      "monitor":{
+          "name":"HTCondorMonitor",
+          "module":"pandaharvester.harvestermonitor.htcondor_monitor",
+          "cancelUnknown":false
+      },
+      "sweeper":{
+          "name":"HTCondorSweeper",
+          "module":"pandaharvester.harvestersweeper.htcondor_sweeper"
+      }
+  },
+  "US_analysis_pull_ups_intel":{
       "isTemplateQueue": true,
       "prodSourceLabel":"user",
       "prodSourceLabelRandomWeightsPermille": {"ptest":10, "rc_test":10, "rc_test2":10, "rc_alrb":10},


### PR DESCRIPTION
1) Template US_analysis_pull_intel is now for BNL non-unified intel-only ANALY queues
2) The existing template for the BNL unified intel-only ANALY queue is now more appropriately renamed to US_analysis_pull_ups_intel