### PR TITLE
Use pilot role for analysis in special BNL Intel templates

### DIFF
--- a/GRID/common_grid_queueconfig_template.json
+++ b/GRID/common_grid_queueconfig_template.json
@@ -766,7 +766,7 @@
           "useSpool":false,
           "useAtlasGridCE":true,
           "templateFile":"/cephfs/atlpan/harvester/harvester_common/htcondor_atlas-grid-ce_pull.sdf.d/htcondor-ce-intel_pilot2.sdf",
-          "x509UserProxy":"/cephfs/atlpan/harvester/proxy/x509up_u25606_prod",
+          "x509UserProxy":"/cephfs/atlpan/harvester/proxy/x509up_u25606_pilot",
           "logDir":"/data2/atlpan/condor_logs",
           "logBaseURL":"https://[ScheddHostname]/condor_logs_2",
           "nProcesses":8
@@ -840,7 +840,7 @@
           "useAtlasGridCE":true,
           "templateFile":"/cephfs/atlpan/harvester/harvester_common/htcondor_atlas-grid-ce_pull.sdf.d/htcondor-ce-intel_pilot2.sdf",
           "x509UserProxy":"/cephfs/atlpan/harvester/proxy/x509up_u25606_prod",
-          "x509UserProxyAnalysis":"/cephfs/atlpan/harvester/proxy/x509up_u25606_prod",
+          "x509UserProxyAnalysis":"/cephfs/atlpan/harvester/proxy/x509up_u25606_pilot",
           "logDir":"/data2/atlpan/condor_logs",
           "logBaseURL":"https://[ScheddHostname]/condor_logs_2",
           "nProcesses":8


### PR DESCRIPTION
BNL has recently swtiched to using pilot role for analysis, and all standard queues are now using the default templates. Applying the change also to the special queues using intel-only templates.