### PR TITLE
small cleanups, new image for CA-VICTORIA-K8S-TEST-T2

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
@@ -9,7 +9,6 @@ spec:
   # can use activeDeadlineSeconds to set a time limit (in job spec or pod spec)
   template:
     spec:
-      # schedulerName: node-packing-scheduler # TODO: use custom scheduler
       restartPolicy: Never
       containers:
         - name: job-container
@@ -64,7 +63,6 @@ spec:
             - name: PILOT_NOKILL
               value: "True"
           command: ["/usr/bin/bash"]
-          # args: ["-c", "cd; wget https://raw.githubusercontent.com/HSF/harvester/master/pandaharvester/harvestercloud/k8s_startup_script.py; python k8s_startup_script.py"]
           args: ["-c", "cd; wget https://raw.githubusercontent.com/HSF/harvester/master/pandaharvester/harvestercloud/pilots_starter.py; chmod 755 pilots_starter.py; ./pilots_starter.py"]
       volumes:
         - name: cvmfs-atlas

--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -9,11 +9,10 @@ spec:
   # can use activeDeadlineSeconds to set a time limit (in job spec or pod spec)
   template:
     spec:
-      # schedulerName: node-packing-scheduler # TODO: use custom scheduler
       restartPolicy: Never
       containers:
         - name: job-container
-          image: registry.hub.docker.com/atlasadc/atlas-grid-centos7@sha256:d7fd2ab42ef5c08526d1fafea922a88b9425937d597361adce80c7faa9b0998b
+          image: git.computecanada.ca:4567/rptaylor/misc/atlas-grid-centos7-localuser@sha256:317e213f2333567b1316f1c04dcd6427ed96bcdc127e63c4c71098b680fbcb97
           volumeMounts:
             - name: cvmfs-atlas
               mountPath: /cvmfs/atlas.cern.ch
@@ -84,4 +83,4 @@ spec:
           secret:
             secretName: proxy-secret
         - name: pilot-dir
-            emptyDir: {}
+          emptyDir: {}


### PR DESCRIPTION
@fbarreir Here is a new image to use for the test queue, for the time being there is still a need for a local user account defined in the image to work around some remaining issues. But we are several steps closer to using the atlas-grid-centos7 image directly.

Image is hosted on our CC gitlab.
Please apply the new YAML on the Harvester node for the test queue.

Thanks!