### PR TITLE
20210319 unpacked repo

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
@@ -26,6 +26,9 @@ spec:
             - name: cvmfs-sft
               mountPath: /cvmfs/sft.cern.ch
               readOnly: true
+            - name: cvmfs-unpacked
+              mountPath: /cvmfs/unpacked.cern.ch
+              readOnly: true
             - name: secret-volume
               mountPath: /proxy
               readOnly: true
@@ -78,6 +81,10 @@ spec:
         - name: cvmfs-sft
           hostPath:
             path: /cvmfs/sft.cern.ch
+            type: Directory
+        - name: cvmfs-unpacked
+          hostPath:
+            path: /cvmfs/unpacked.cern.ch
             type: Directory
         - name: secret-volume
           secret:

--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -26,6 +26,9 @@ spec:
             - name: cvmfs-sft
               mountPath: /cvmfs/sft.cern.ch
               readOnly: true
+            - name: cvmfs-unpacked
+              mountPath: /cvmfs/unpacked.cern.ch
+              readOnly: true
             - name: secret-volume
               mountPath: /proxy
               readOnly: true
@@ -78,6 +81,10 @@ spec:
         - name: cvmfs-sft
           hostPath:
             path: /cvmfs/sft.cern.ch
+            type: Directory
+        - name: cvmfs-unpacked
+          hostPath:
+            path: /cvmfs/unpacked.cern.ch
             type: Directory
         - name: secret-volume
           secret:


### PR DESCRIPTION
@fbarreir 

BTW it would be possible to provide "all" CVMFS repos from the node like this
```
    - name: cvmfs
      mountPath: /cvmfs
      readOnly: true
      mountPropagation: HostToContainer
```
but I think it is better to explicitly enumerate each one that is required, to avoid failures e.g. in case some repos become unavailable on some nodes.