### PR TITLE
Revert "temporarily enable xrootd debugging"

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
@@ -39,8 +39,8 @@ spec:
           env:
             - name: PILOT_NOKILL
               value: "True"
-          command: ["/usr/bin/bash"]
-          args: ["-c", "cd; export XRD_LOGLEVEL=Debug; python3 $EXEC_DIR/pilots_starter.py || true"]
+          # command: ["/usr/bin/bash"]
+          # args: ["-c", "cd; python3 $EXEC_DIR/pilots_starter.py || true"]
       volumes:
         - name: cvmfs-atlas
           hostPath:


### PR DESCRIPTION
This reverts commit d31a6dc6549e618b56bf2eac954f42a46b86a1d8.
It was only for short term urgent debugging.