### PR TITLE
update securityContext for CA-VICTORIA-K8S-TEST-T2

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -12,6 +12,18 @@ spec:
       containers:
         - name: job-container
           image: git.computecanada.ca:4567/rptaylor/misc/atlas-grid-almalinux9-localuser:20240124
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            runAsGroup: 10000
+            runAsUser: 10000
+            readOnlyRootFilesystem: true
+            seccompProfile: 
+              type: Unconfined
           volumeMounts:
             - name: cvmfs-atlas
               mountPath: /cvmfs/atlas.cern.ch/repo


### PR DESCRIPTION
Set explicit security controls instead of relying on PSP mutation. Related to Kyverno implementation.

FYI @fbarreir  do you see any issue with this?

@sbathgate can you check this has everything we need?