### PR TITLE
UVic: defer read-only filesystem for now

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
@@ -40,7 +40,7 @@ spec:
             - name: PILOT_NOKILL
               value: "True"
           # command: ["/usr/bin/bash"]
-          # args: ["-c", "cd; python3 $EXEC_DIR/pilots_starter.py || true"]
+          # args: ["-c", "cd; python3 $EXEC_DIR/pilots_starter.py"]
       volumes:
         - name: cvmfs-atlas
           hostPath:

--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -21,7 +21,6 @@ spec:
             runAsNonRoot: true
             runAsGroup: 10000
             runAsUser: 10000
-            readOnlyRootFilesystem: true
             seccompProfile: 
               type: Unconfined
           volumeMounts:


### PR DESCRIPTION
I found other issues with the read only filesystem.

The ALRB setup calls /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/utilities/guessFrontier.sh
which calls  /cvmfs/atlas.cern.ch/repo/sw/local/bin/auto-setup
which calls  /cvmfs/atlas.cern.ch/repo/sw/local/bin/cric-site-info
which calls /cvmfs/atlas.cern.ch/repo/sw/local/bin/cric_site_info.py
and eventually there is a string that selects /var/tmp as a writeable location for CRIC cache info.

This is meant to be a shared semi-persistent cache used by all jobs on a node and /var/tmp is in the FHS so I don't think we can get away from that easily. Defer the use of readOnlyRootFilesystem for now, can maybe revisit later.

Also clean up the args comment.