### PR TITLE
CA-VICTORIA-K8S-T2 security context

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-T2_job.yaml
@@ -12,6 +12,17 @@ spec:
       containers:
         - name: job-container
           image: git.computecanada.ca:4567/rptaylor/misc/atlas-grid-almalinux9-localuser:20240124
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            runAsGroup: 10000
+            runAsUser: 10000
+            seccompProfile: 
+              type: Unconfined
           volumeMounts:
             - name: cvmfs-atlas
               mountPath: /cvmfs/atlas.cern.ch/repo


### PR DESCRIPTION
Apply security context based on https://github.com/PanDAWMS/harvester_configurations/pull/83 ([except readonly filesystem](https://github.com/PanDAWMS/harvester_configurations/pull/85))