### PR TITLE
CA-VICTORIA-K8S-TEST-T2 set fsGroup, YAML cleanup

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -9,6 +9,13 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        seccompProfile:
+          type: Unconfined
       containers:
         - name: job-container
           image: git.computecanada.ca:4567/rptaylor/misc/atlas-grid-almalinux9-localuser:20240704
@@ -17,12 +24,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
-            runAsNonRoot: true
-            runAsGroup: 10000
-            runAsUser: 10000
-            seccompProfile: 
-              type: Unconfined
+                - ALL
           volumeMounts:
             - name: cvmfs-atlas
               mountPath: /cvmfs/atlas.cern.ch/repo


### PR DESCRIPTION
We also need to explicitly set fsGroup, so that mounted secrets are readable after PSP deprecation.

Clean lint.

Move some settings to pod-level securityContext instead of container-level.


FYI @fbarreir 