### PR TITLE
set node affinity for CA-VICTORIA-K8S-TEST-T2

### DIFF
--- a/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
+++ b/K8S/job_templates/CA-VICTORIA-K8S-TEST-T2_job.yaml
@@ -16,6 +16,13 @@ spec:
         fsGroup: 10000
         seccompProfile:
           type: Unconfined
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: rcs.uvic.ca/node-type
+                operator: DoesNotExist
       containers:
         - name: job-container
           image: git.computecanada.ca:4567/rptaylor/misc/atlas-grid-almalinux9-localuser:20240704


### PR DESCRIPTION
This sets a node affinity requirement for the `rcs.uvic.ca/node-type` label to not exist.

We are deploying special "service" nodes which will have this label defined. This will ensure Harvester jobs don't run on the service nodes, only on regular nodes without any node-type label.

FYI  @fbarreir do you anticipate any issue with this configuration?
We have [k8s.scheduler.use_score_mcore_anti_affinity](https://atlas-cric.cern.ch/atlas/cresourceparam/list/?name=k8s.scheduler.use_score_mcore_anti_affinity) set to false so there is no other affinity definition currently.